### PR TITLE
Adding multipath config options

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -38,13 +38,25 @@ options:
     type: string
     default: 
     description: |
-      Name of a storage pool to be used. If you need to configure multiple storage pools, 
-      separate them by semicolons (;).
-  defaulttargetip:
+      Name of a storage pool to be used. Multiple pools are allowed,
+      separated by the semicolons (;).
+  iscsidefaulttargetip:
     type: string
     default: 
     description: |
-      Default IP address of the iSCSI target port that is provided for compute nodes.
+      Default IP address of the iSCSI target that is provided for compute nodes.
+  iscsiinitiators:
+    type: string
+    default:
+    description: |
+      List of iSCSI initiators names, separated by the semicolons. Can be acquired
+      from the /etc/iscsi/initiatorname.iscsi on the compute host.
+  iscsiportgroupname:
+    type: string
+    default:
+    description: |
+      Port Group name on the storage array side. This has to be configured
+      in order to use the iSCSI multipathing.
   volume-backend-name:
     type: string
     default: oceanstor
@@ -60,7 +72,7 @@ options:
     default: fastclone
     description: |
         LUN clone mode. The value can be fastclone or luncopy.
-        Only Dorado supports fastclone.Dorado V300R001C20 and later versionssupport luncopy.
+        Only Dorado supports fastclone. Dorado V300R001C20 and later versions support luncopy.
         Other storage devicessupport only luncopy
   hypersyncspeed:
     type: int
@@ -79,7 +91,7 @@ options:
     default: 1
     description: |
         Initiator switchover mode.
-        This parameterneeds to be delivered only when third-partymultipathing software is used.
+        This parameterneeds to be delivered only when third-party multipathing software is used.
         0: early-version ALUA
         1: common ALUA
         2: ALUA not used
@@ -89,7 +101,7 @@ options:
     default: 0
     description: |
         Initiator path type.
-        This parameter needs to bedelivered only when third-party multipathing software is used.
+        This parameter needs to be delivered only when third-party multipathing software is used.
         0: optimal path
         1: non-optimal path
   hypermetro:

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -1,9 +1,9 @@
 options:
   product:
     type: string
-    default: v5
+    default: Dorado
     description: |
-      Type of a storage product. Possible values are TV2, 18000 and V3. 
+      Type of a storage product. Possible values are TV2, 18000, V3 and Dorado.
   protocol:
     type: string
     default: iSCSI
@@ -96,7 +96,9 @@ options:
     type: boolean
     default: False
     description: |
-      "A short description of the configuration option"
+      This parameter describes, whether the HyperMetro sync is enabled on the driver side or not.
+      Prior to enabling this option in the charm, the HyperMetro domain should be configured
+      on the storage array side.
   fchostname:
     type: string
     default:
@@ -113,3 +115,15 @@ options:
     default: domain
     description: |
       Hypermetro domain name
+  use-multipath-for-image-xfer:
+    type: boolean
+    default: true
+    description: |
+      Determines, whether a volume attach/detach in cinder will happen using multipath
+      for volume to image and image to volume transfers.
+  enforce-multipath-image-xfer:
+    type: boolean
+    default: true
+    description: |
+      If this is set to True, attachment of volumes for image transfer will be
+      aborted, when multipathd is not  running. Otherwise, it will fallback to single path.

--- a/src/lib/charm/openstack/cinder_oceanstor.py
+++ b/src/lib/charm/openstack/cinder_oceanstor.py
@@ -19,8 +19,7 @@ class CinderoceanstorCharm(charms_openstack.charm.CinderStoragePluginCharm):
 
     # Specify any config that the user *must* set.
     mandatory_config = [
-        'username', 'userpassword', 'resturl',
-        'storagepool', 'defaulttargetip'
+        'username', 'userpassword', 'resturl', 'storagepool', 'protocol'
     ]
 
     driver_config_file_iscsi = "/etc/cinder/cinder_huawei_conf.xml"

--- a/src/lib/charm/openstack/cinder_oceanstor.py
+++ b/src/lib/charm/openstack/cinder_oceanstor.py
@@ -4,12 +4,11 @@ import charmhelpers.core.hookenv as ch_hookenv  # noqa
 charms_openstack.charm.use_defaults('charm.default-select-release')
 
 
-class   ProtocolNotImplimented(Exception):
+class ProtocolNotImplemented(Exception):
     """Unsupported protocol error."""
 
 
-class CinderoceanstorCharm(
-        charms_openstack.charm.CinderStoragePluginCharm):
+class CinderoceanstorCharm(charms_openstack.charm.CinderStoragePluginCharm):
 
     name = 'cinder_oceanstor'
     version_package = ''
@@ -17,58 +16,88 @@ class CinderoceanstorCharm(
     packages = [version_package]
     release_pkg = ''
     stateless = True
+
     # Specify any config that the user *must* set.
-    mandatory_config = ['username', 'userpassword', 'resturl', 'storagepool', 'defaulttargetip']
-    driver_config_file_iscsi="/etc/cinder/cinder_huawei_conf.xml"
+    mandatory_config = [
+        'username', 'userpassword', 'resturl',
+        'storagepool', 'defaulttargetip'
+    ]
+
+    driver_config_file_iscsi = "/etc/cinder/cinder_huawei_conf.xml"
     driver_config_file_fc = "/etc/cinder/cinder_huawei_fc_conf.xml"
 
-    restart_map = {driver_config_file_iscsi: ['cinder-volume'],
-                   driver_config_file_fc: ['cinder-volume']}
+    restart_map = {
+        driver_config_file_iscsi: ['cinder-volume'],
+        driver_config_file_fc: ['cinder-volume']
+    }
 
     def cinder_configuration(self):
+        base_driver = 'cinder.volume.drivers.huawei.huawei_driver.{0}'
         drivers = {
-            'iscsi': 'cinder.volume.drivers.huawei.huawei_driver.HuaweiISCSIDriver',
-            'fc': 'cinder.volume.drivers.huawei.huawei_driver.HuaweiFCDriver',
+            'iscsi': base_driver.format('HuaweiISCSIDriver'),
+            'fc': base_driver.format('HuaweiFCDriver'),
         }
 
         volume_driver = drivers.get(self.config.get('protocol').lower())
         service = self.config.get('volume-backend-name')
 
-        if self.config.get('protocol').lower() == "fc":
+        protocol = self.config.get('protocol').lower()
+        if protocol == "fc":
             driver_config_file = self.driver_config_file_fc
-        elif self.config.get('protocol').lower() == "iscsi":
+        elif protocol == "iscsi":
             driver_config_file = self.driver_config_file_iscsi
         else:
-            raise ProtocolNotImplimented(
-                self.config.get('protocol'), ' is not an implimented protocol  driver, '
-                                    'please choose between `iscsi` and `fc`.')
+            raise ProtocolNotImplemented(
+                "{0} is not an implemented protocol. Please, choose between "
+                "`iscsi` and `fc`.".format(protocol)
+            )
+
+        use_mpath_img_xfer = self.config.get('use-multipath-for-image-xfer')
+        enforce_multipath = self.config.get('enforce-multipath-image-xfer')
 
         driver_options = [
             ('volume_driver', volume_driver),
             ('cinder_huawei_conf_file', driver_config_file),
             ('volume_backend_name', service),
-            # Add config options that needs setting on cinder.conf
+            ('use_multipath_for_image_xfer', use_mpath_img_xfer),
+            ('enforce_multipath_for_image_xfer', enforce_multipath)
         ]
 
         if self.config.get('hypermetro'):
+            config_keys = [
+                'storagepool', 'resturl', 'username', 'userpassword',
+                'vstorename', 'metrodomain'
+            ]
+
+            for k in config_keys:
+                if not self.config.get(k):
+                    raise ProtocolNotImplemented(
+                        "HyperMetro init error: {0} option is required".format(
+                            k
+                        )
+                    )
             hypermetro_options = ('''storage_pool:{0},
             san_address:{1},
             san_user:{2},
             san_password:{3},
             vstore_name:{4},
             metro_domain:{5},
-            metro_sync_completed:True, 
+            metro_sync_completed:True,
             fc_info: '{'HostName:xxx;ALUA:1;FAILOVERMODE:1;PATHTYPE:0'}'
-            ''').format(self.config.get('storagepool'), self.config.get('resturl'),
-                        self.config.get('username'), self.config.get('userpassword'),
-                        self.config.get('vstorename'), self.config.get('metrodomain'))
+            ''').format(
+                self.config.get('storagepool'),
+                self.config.get('resturl'),
+                self.config.get('username'),
+                self.config.get('userpassword'),
+                self.config.get('vstorename'),
+                self.config.get('metrodomain')
+            )
             driver_options.append(('hypermetro_device', hypermetro_options))
 
         return driver_options
 
 
 class CinderoceanstorCharmRocky(CinderoceanstorCharm):
-
     # Rocky needs py3 packages.
     release = 'rocky'
     version_package = ''

--- a/src/templates/cinder_huawei_conf.xml
+++ b/src/templates/cinder_huawei_conf.xml
@@ -1,17 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config>
     <Storage>
-       <Product>{{ options.product }}</Product>
-       <Protocol>{{ options.protocol }}</Protocol>
-       <UserName>{{ options.username }}</UserName>
-       <UserPassword>{{ options.userpassword }}</UserPassword>
-       <RestURL>{{ options.resturl }}</RestURL>
+        <Product>{{ options.product }}</Product>
+        <Protocol>{{ options.protocol }}</Protocol>
+        <UserName>{{ options.username }}</UserName>
+        <UserPassword>{{ options.userpassword }}</UserPassword>
+        <RestURL>{{ options.resturl }}</RestURL>
     </Storage>
     <LUN>
-       <LUNType>{{ options.luntype }}</LUNType>
-       <StoragePool>{{ options.storagepool }}</StoragePool>
+        <LUNType>{{ options.luntype }}</LUNType>
+        <StoragePool>{{ options.storagepool }}</StoragePool>
     </LUN>
     <iSCSI>
-       <DefaultTargetIP>{{ options.defaulttargetip }}</DefaultTargetIP>
+        <DefaultTargetIP>{{ options.iscsidefaulttargetip }}</DefaultTargetIP>
+        {% set initiators = options.iscsiinitiators.split(';') %}
+        {% for initiator in initiators %}
+        <Initiator Name="{{ initiator }}" TargetPortGroup="{{ options.iscsiportgroupname }}" />
+        {% endfor %}
     </iSCSI>
 </config>

--- a/src/wheelhouse.txt
+++ b/src/wheelhouse.txt
@@ -1,2 +1,5 @@
 #layer-basic uses wheelhouse to install python dependencies
 psutil
+
+git+https://opendev.org/openstack/charms.openstack.git@stable/21.04#egg=charms.openstack
+git+https://github.com/juju/charm-helpers.git@stable/21.04#egg=charmhelpers


### PR DESCRIPTION
As per
https://docs.openstack.org/cinder/ussuri/configuration/block-storage/drivers/huawei-storage-driver.html,
these options should be present in cinder.conf to utilize the
multipathing features of the driver.