### PR TITLE
Improving credential handling

### DIFF
--- a/src/lib/charm/openstack/cinder_oceanstor.py
+++ b/src/lib/charm/openstack/cinder_oceanstor.py
@@ -31,6 +31,9 @@ class CinderoceanstorCharm(charms_openstack.charm.CinderStoragePluginCharm):
     }
 
     def cinder_configuration(self):
+        self.config['username'] = self.config.get('username').strip()
+        self.config['userpassword'] = self.config.get('userpassword').strip()
+
         base_driver = 'cinder.volume.drivers.huawei.huawei_driver.{0}'
         drivers = {
             'iscsi': base_driver.format('HuaweiISCSIDriver'),

--- a/src/templates/cinder_huawei_conf.xml
+++ b/src/templates/cinder_huawei_conf.xml
@@ -13,9 +13,11 @@
     </LUN>
     <iSCSI>
         <DefaultTargetIP>{{ options.iscsidefaulttargetip }}</DefaultTargetIP>
+        {% if options.iscsiinitiators != '' -%}
         {% set initiators = options.iscsiinitiators.split(';') %}
-        {% for initiator in initiators %}
+        {% for initiator in initiators -%}
         <Initiator Name="{{ initiator }}" TargetPortGroup="{{ options.iscsiportgroupname }}" />
         {% endfor %}
+        {% endif %}
     </iSCSI>
 </config>


### PR DESCRIPTION
This PR introduces the following changes:

1) A storage credentials are being stripped of carriage return symbols. This prevents a situations, when the creds are read from the local filesystem, adding carriage return symbol unintentionally.
2) Prettifying an Initiator list rendering and preventing the empty Initiator entry from rendering if there is no `iscsiinitiators` defined.